### PR TITLE
Use SHA256 instead of md5

### DIFF
--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -28,7 +28,7 @@ import codecs
 import ipaddress
 import pickle
 from datetime import datetime
-from hashlib import md5
+from hashlib import sha256
 
 from pytest import raises
 
@@ -390,7 +390,7 @@ def test_docs_with_properties():
         pwd_hash = field.Text()
 
         def check_password(self, pwd):
-            return md5(pwd).hexdigest() == self.pwd_hash
+            return sha256(pwd).hexdigest() == self.pwd_hash
 
         @property
         def password(self):
@@ -398,9 +398,9 @@ def test_docs_with_properties():
 
         @password.setter
         def password(self, pwd):
-            self.pwd_hash = md5(pwd).hexdigest()
+            self.pwd_hash = sha256(pwd).hexdigest()
 
-    u = User(pwd_hash=md5(b"secret").hexdigest())
+    u = User(pwd_hash=sha256(b"secret").hexdigest())
     assert u.check_password(b"secret")
     assert not u.check_password(b"not-secret")
 


### PR DESCRIPTION
Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Description
According to security recommendations, use sha256 over md5
  
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
