### PR TITLE
Adding support to run integration tests against unreleased OpenSearch

### DIFF
--- a/.github/workflows/integration-unreleased.yml
+++ b/.github/workflows/integration-unreleased.yml
@@ -1,0 +1,45 @@
+name: Integration with Unreleased OpenSearch
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        entry:
+          - { opensearch_ref: '1.x' }
+          - { opensearch_ref: '2.x' }
+          - { opensearch_ref: '2.0' }
+          - { opensearch_ref: 'main' }
+    steps:
+      - name: Checkout OpenSearch
+        uses: actions/checkout@v2
+        with:
+          repository: opensearch-project/opensearch
+          ref: ${{ matrix.entry.opensearch_ref }}
+          path: opensearch
+
+        # This step builds the docker image tagged as opensearch:test. It will be further used in /ci/run-tests to test against unreleased OpenSearch.
+        # Reference: https://github.com/opensearch-project/OpenSearch/blob/2.0/distribution/docker/build.gradle#L190
+      - name: Assemble OpenSearch
+        run: |
+          cd opensearch
+          ./gradlew assemble
+
+      - name: Checkout High Level Python Client
+        uses: actions/checkout@v2
+
+      - name: Install Nox
+        run: pip install nox
+
+      - name: Run integration tests
+        run: |
+          nox -rs lint test


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
Add workflow to run integration tests against unreleased OpenSearch. This helps to get the client ready for the upcoming release.

### Issues Resolved
#43 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
