### PR TITLE
Type removal changes for 2.0

### DIFF
--- a/.github/workflows/integration-unreleased.yml
+++ b/.github/workflows/integration-unreleased.yml
@@ -27,12 +27,17 @@ jobs:
           ref: ${{ matrix.entry.opensearch_ref }}
           path: opensearch
 
-        # This step builds the docker image tagged as opensearch:test. It will be further used in /ci/run-tests to test against unreleased OpenSearch.
-        # Reference: https://github.com/opensearch-project/OpenSearch/blob/2.0/distribution/docker/build.gradle#L190
       - name: Assemble OpenSearch
         run: |
           cd opensearch
           ./gradlew assemble
+
+        # This step runs the docker image generated during gradle assemble in OpenSearch. It is tagged as opensearch:test.
+        # Reference: https://github.com/opensearch-project/OpenSearch/blob/2.0/distribution/docker/build.gradle#L190
+      - name: Run Docker Image
+        run: |
+          docker run -p 9200:9200 -p 9600:9600 -d -e "discovery.type=single-node" -e "bootstrap.memory_lock=true" opensearch:test
+          sleep 90
 
       - name: Checkout High Level Python Client
         uses: actions/checkout@v2

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,6 +20,7 @@ jobs:
           - { cluster: 'opensearch', version: 1.2.4 }
           - { cluster: 'opensearch', version: 1.3.0 }
           - { cluster: 'opensearch', version: 1.3.1 }
+          - { cluster: 'opensearch', version: 2.0.0 }
           - { cluster: 'opendistro', version: 'latest' }
         secured: ["true", "false"]
 

--- a/opensearch_dsl/index.py
+++ b/opensearch_dsl/index.py
@@ -424,17 +424,6 @@ class Index(object):
         """
         return self._get_connection(using).indices.exists(index=self._name, **kwargs)
 
-    def exists_type(self, using=None, **kwargs):
-        """
-        Check if a type/types exists in the index.
-
-        Any additional keyword arguments will be passed to
-        ``OpenSearch.indices.exists_type`` unchanged.
-        """
-        return self._get_connection(using).indices.exists_type(
-            index=self._name, **kwargs
-        )
-
     def put_mapping(self, using=None, **kwargs):
         """
         Register specific mapping definition for a specific type.
@@ -598,18 +587,6 @@ class Index(object):
         ``OpenSearch.indices.get_upgrade`` unchanged.
         """
         return self._get_connection(using).indices.get_upgrade(
-            index=self._name, **kwargs
-        )
-
-    def flush_synced(self, using=None, **kwargs):
-        """
-        Perform a normal flush, then add a generated unique marker (sync_id) to
-        all shards.
-
-        Any additional keyword arguments will be passed to
-        ``OpenSearch.indices.flush_synced`` unchanged.
-        """
-        return self._get_connection(using).indices.flush_synced(
             index=self._name, **kwargs
         )
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ f.close()
 install_requires = [
     "six",
     "python-dateutil",
-    "opensearch-py>=1.0.0",
+    "opensearch-py>=2.0.0",
     # ipaddress is included in stdlib since python 3.3
     'ipaddress; python_version<"3.3"',
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,14 +121,12 @@ def dummy_response():
             "hits": [
                 {
                     "_index": "test-index",
-                    "_type": "company",
                     "_id": "opensearch",
                     "_score": 12.0,
                     "_source": {"city": "Amsterdam", "name": "OpenSearch"},
                 },
                 {
                     "_index": "test-index",
-                    "_type": "employee",
                     "_id": "42",
                     "_score": 11.123,
                     "_routing": "opensearch",
@@ -140,7 +138,6 @@ def dummy_response():
                 },
                 {
                     "_index": "test-index",
-                    "_type": "employee",
                     "_id": "47",
                     "_score": 1,
                     "_routing": "opensearch",
@@ -152,7 +149,6 @@ def dummy_response():
                 },
                 {
                     "_index": "test-index",
-                    "_type": "employee",
                     "_id": "53",
                     "_score": 16.0,
                     "_routing": "opensearch",

--- a/tests/test_integration/test_document.py
+++ b/tests/test_integration/test_document.py
@@ -282,32 +282,22 @@ def test_save_and_update_return_doc_meta(write_client):
     resp = w.save(return_doc_meta=True)
     assert resp["_index"] == "test-wiki"
     assert resp["result"] == "created"
-    assert set(resp.keys()) == {
-        "_id",
-        "_index",
-        "_primary_term",
-        "_seq_no",
-        "_shards",
-        "_type",
-        "_version",
-        "result",
-    }
+    assert resp.keys().__contains__("_id")
+    assert resp.keys().__contains__("_primary_term")
+    assert resp.keys().__contains__("_seq_no")
+    assert resp.keys().__contains__("_shards")
+    assert resp.keys().__contains__("_version")
 
     resp = w.update(
         script="ctx._source.views += params.inc", inc=5, return_doc_meta=True
     )
     assert resp["_index"] == "test-wiki"
     assert resp["result"] == "updated"
-    assert set(resp.keys()) == {
-        "_id",
-        "_index",
-        "_primary_term",
-        "_seq_no",
-        "_shards",
-        "_type",
-        "_version",
-        "result",
-    }
+    assert resp.keys().__contains__("_id")
+    assert resp.keys().__contains__("_primary_term")
+    assert resp.keys().__contains__("_seq_no")
+    assert resp.keys().__contains__("_shards")
+    assert resp.keys().__contains__("_version")
 
 
 def test_init(write_client):

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -73,16 +73,6 @@ def test_response_stores_search(dummy_response):
     assert r._search is s
 
 
-def test_attribute_error_in_hits_is_not_hidden(dummy_response):
-    def f(hit):
-        raise AttributeError()
-
-    s = Search().doc_type(employee=f)
-    r = response.Response(s, dummy_response)
-    with raises(TypeError):
-        r.hits
-
-
 def test_interactive_helpers(dummy_response):
     res = response.Response(Search(), dummy_response)
     hits = res.hits
@@ -129,7 +119,6 @@ def test_iterating_over_response_gives_you_hits(dummy_response):
     h = hits[0]
 
     assert "test-index" == h.meta.index
-    assert "company" == h.meta.doc_type
     assert "opensearch" == h.meta.id
     assert 12 == h.meta.score
 


### PR DESCRIPTION
### Description
* Type removal changes related to OpenSearch 2.0.
* Upgrading to `opensearch-py` 2.0.0.
* Adding OpenSearch 2.0 to the test matrix.

### Issues Resolved
#43 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
