### PR TITLE
Add release workflows

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,31 @@
+name: Release drafter
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  lint:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Set up Python 3
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.x'
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade build
+      - name: Build project for distribution
+        run: |
+          python -m build
+          tar -zvcf artifacts.tar.gz dist
+      - name: Draft a release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          generate_release_notes: true
+          files: |
+            artifacts.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Github workflow for changelog verification ([#81](https://github.com/opensearch-project/opensearch-dsl-py/pull/81))
 - Added AttrDict .get(...) method ([#90](https://github.com/opensearch-project/opensearch-dsl-py/pull/90))
+- Add release workflows ([#84](https://github.com/opensearch-project/opensearch-dsl-py/pull/84))
 
 ### Changed
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -31,4 +31,11 @@ Repositories create consistent release labels, such as `v1.0.0`, `v1.1.0` and `v
 
 ## Releasing
 
-The release process is standard across repositories in this org and is run by a release manager volunteering from amongst [MAINTAINERS](MAINTAINERS.md).
+The release process is standard across repositories in this org and is run by a release manager volunteering from amongst [maintainers](MAINTAINERS.md).
+
+1. Create a tag, e.g. v2.1.0, and push it to the GitHub repo.
+1. The [release-drafter.yml](.github/workflows/release-drafter.yml) will be automatically kicked off and a draft release will be created.
+1. This draft release triggers the [jenkins release workflow](https://build.ci.opensearch.org/job/opensearch-dsl-py-release/) as a result of which opensearch-dsl-py client is released on [PyPi](https://pypi.org/project/opensearch-dsl/).
+1. Once the above release workflow is successful, the drafted release on GitHub is published automatically.
+1. Increment "VERSION" in [__init__.py](./opensearch_dsl/__init__.py) and [setup.py](./setup.py) to the next patch release, e.g. v2.1.1. See [example](https://github.com/opensearch-project/opensearch-dsl-py/pull/55).
+

--- a/jenkins/release.JenkinsFile
+++ b/jenkins/release.JenkinsFile
@@ -1,0 +1,12 @@
+lib = library(identifier: 'jenkins@1.3.1', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
+
+standardReleasePipelineWithGenericTrigger(
+    tokenIdCredential: 'jenkins-opensearch-dsl-py-generic-webhook-token',
+    causeString: 'A tag was cut on opensearch-project/opensearch-dsl-py repository causing this workflow to run',
+    downloadReleaseAsset: true,
+    publishRelease: true) {
+        publishToPyPi(credentialId: 'jenkins-opensearch-dsl-py-pypi-credentials')
+    }


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
This PR adds below things:

* A GitHub action workflow that will be triggered when a tag is pushed to this repository. The workflow builds the product and creates a draft release with built artifacts attached as artifacts.tar.gz in the release.
* A jenkins workflow that is triggered based on above draft release. The workflow looks for artifacts.tar.gz, downloads it and then signs it and publishes it to [PyPi](https://pypi.org/)

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass.
- [ ] New functionality has been documented.
  - [ ] New functionality has comments added.
- [ ] Commits are signed per the DCO using --signoff.
- [ ] [CHANGELOG](https://github.com/opensearch-project/opensearch-dsl-py/blob/main/CONTRIBUTING.md#changelog) has been updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following the Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-dsl-py/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).