### PR TITLE
Update CI workflows to use more Python and OpenSearch versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7, 3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [2.7, 3.7, 3.8, 3.9, 3.10, 3.11]
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install dependencies
@@ -28,9 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install dependencies
@@ -43,9 +43,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Set up Python 3.7
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
       - name: Install build tools
@@ -56,23 +56,32 @@ jobs:
           python3.7 -m build
 
   test-linux:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
 
     strategy:
       fail-fast: false
       matrix:
         python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', '3.11']
+        runner: ['ubuntu-latest']
+        include:
+          - runner: 'ubuntu-20.04'
+            python-version: '3.5'
+          - runner: 'ubuntu-20.04'
+            python-version: '3.6'
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Setup Python - ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+        env:
+          PIP_NO_PYTHON_VERSION_WARNING: 1
+          PIP_DISABLE_PIP_VERSION_CHECK: 1
       - name: Set up Python 3.8 for Nox
         if: matrix.python-version != '3.8'
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install nox

--- a/.github/workflows/integration-unreleased.yml
+++ b/.github/workflows/integration-unreleased.yml
@@ -7,13 +7,13 @@ on:
       - "main"
 
 jobs:
-  test-ubuntu-22:
+  integ-test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         opensearch_ref: [ '1.x', '2.x', '2.0', 'main' ]
-        python-version: [ '2.7', '3.7', '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.8' ]
 
     steps:
       - name: Checkout OpenSearch
@@ -50,8 +50,6 @@ jobs:
       - name: Run OpenSearch
         working-directory: opensearch/distribution/archives/linux-tar/build/distributions
         run: |
-          pwd
-          tree
           tar xf opensearch-min-*
           ./opensearch-*/bin/opensearch &
           for attempt in {1..20}; do sleep 5; if curl -s localhost:9200; then echo '=====> ready'; break; fi; echo '=====> waiting...'; done
@@ -68,97 +66,9 @@ jobs:
         env:
           PIP_NO_PYTHON_VERSION_WARNING: 1
 
-      - name: Set up Python 3.8 for Nox
-        if: matrix.python-version != '3.8'
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.8
       - name: Install nox
         run: |
-          python3.8 -m pip install nox
-
-      - name: Run integration tests
-        working-directory: dsl-py
-        run: |
-          nox --no-error-on-missing-interpreter -rs lint test
-
-      - name: Save server logs
-        if: failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: opensearch-logs-${{ matrix.opensearch_ref }}-python-${{ matrix.python-version }}
-          path: |
-            opensearch/distribution/archives/linux-tar/build/distributions/**/logs/*
-
-  test-ubuntu-20:
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        opensearch_ref: [ '1.x', '2.x', '2.0', 'main' ]
-        python-version: [ '3.5', '3.6' ]
-
-    steps:
-      - name: Checkout OpenSearch
-        uses: actions/checkout@v3
-        with:
-          repository: opensearch-project/opensearch
-          ref: ${{ matrix.opensearch_ref }}
-          path: opensearch
-
-      - name: Get OpenSearch branch top
-        id: get-key
-        working-directory: opensearch
-        run: echo key=`git log -1 --format='%H'` >> $GITHUB_OUTPUT
-
-      - name: Restore cached build
-        id: cache-restore
-        uses: actions/cache/restore@v3
-        with:
-          path: opensearch/distribution/archives/linux-tar/build/distributions
-          key: ${{ steps.get-key.outputs.key }}
-
-      - name: Assemble OpenSearch
-        if: steps.cache-restore.outputs.cache-hit != 'true'
-        working-directory: opensearch
-        run: ./gradlew :distribution:archives:linux-tar:assemble
-
-      - name: Save cached build
-        if: steps.cache-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
-        with:
-          path: opensearch/distribution/archives/linux-tar/build/distributions
-          key: ${{ steps.get-key.outputs.key }}
-
-      - name: Run OpenSearch
-        working-directory: opensearch/distribution/archives/linux-tar/build/distributions
-        run: |
-          pwd
-          tree
-          tar xf opensearch-min-*
-          ./opensearch-*/bin/opensearch &
-          for attempt in {1..20}; do sleep 5; if curl -s localhost:9200; then echo '=====> ready'; break; fi; echo '=====> waiting...'; done
-
-      - name: Checkout High Level Python Client
-        uses: actions/checkout@v3
-        with:
-          path: dsl-py
-
-      - name: Setup Python - ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-        env:
-          PIP_NO_PYTHON_VERSION_WARNING: 1
-
-      - name: Set up Python 3.8 for Nox
-        if: matrix.python-version != '3.8'
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.8
-      - name: Install nox
-        run: |
-          python3.8 -m pip install nox
+          python -m pip install nox
 
       - name: Run integration tests
         working-directory: dsl-py

--- a/.github/workflows/integration-unreleased.yml
+++ b/.github/workflows/integration-unreleased.yml
@@ -83,7 +83,7 @@ jobs:
           nox --no-error-on-missing-interpreter -rs lint test
 
       - name: Save server logs
-        if: failed()
+        if: failure()
         uses: actions/upload-artifact@v3
         with:
           name: opensearch-logs-${{ matrix.opensearch_ref }}-python-${{ matrix.python-version }}
@@ -166,7 +166,7 @@ jobs:
           nox --no-error-on-missing-interpreter -rs lint test
 
       - name: Save server logs
-        if: failed()
+        if: failure()
         uses: actions/upload-artifact@v3
         with:
           name: opensearch-logs-${{ matrix.opensearch_ref }}-python-${{ matrix.python-version }}

--- a/.github/workflows/integration-unreleased.yml
+++ b/.github/workflows/integration-unreleased.yml
@@ -2,49 +2,173 @@ name: Integration with Unreleased OpenSearch
 
 on:
   push:
-    branches:
-      - "main"
   pull_request:
     branches:
       - "main"
 
 jobs:
-  test:
+  test-ubuntu-22:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        entry:
-          - { opensearch_ref: '1.x' }
-          - { opensearch_ref: '2.x' }
-          - { opensearch_ref: '2.0' }
-          - { opensearch_ref: 'main' }
+        opensearch_ref: [ '1.x', '2.x', '2.0', 'main' ]
+        python-version: [ '2.7', '3.7', '3.8', '3.9', '3.10', '3.11' ]
+
     steps:
       - name: Checkout OpenSearch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: opensearch-project/opensearch
-          ref: ${{ matrix.entry.opensearch_ref }}
+          ref: ${{ matrix.opensearch_ref }}
           path: opensearch
 
-      - name: Assemble OpenSearch
-        run: |
-          cd opensearch
-          ./gradlew assemble
+      - name: Get OpenSearch branch top
+        id: get-key
+        working-directory: opensearch
+        run: echo key=`git log -1 --format='%H'` >> $GITHUB_OUTPUT
 
-        # This step runs the docker image generated during gradle assemble in OpenSearch. It is tagged as opensearch:test.
-        # Reference: https://github.com/opensearch-project/OpenSearch/blob/2.0/distribution/docker/build.gradle#L190
-      - name: Run Docker Image
+      - name: Restore cached build
+        id: cache-restore
+        uses: actions/cache/restore@v3
+        with:
+          path: opensearch/distribution/archives/linux-tar/build/distributions
+          key: ${{ steps.get-key.outputs.key }}
+
+      - name: Assemble OpenSearch
+        if: steps.cache-restore.outputs.cache-hit != 'true'
+        working-directory: opensearch
+        run: ./gradlew :distribution:archives:linux-tar:assemble
+
+      - name: Save cached build
+        if: steps.cache-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        with:
+          path: opensearch/distribution/archives/linux-tar/build/distributions
+          key: ${{ steps.get-key.outputs.key }}
+
+      - name: Run OpenSearch
+        working-directory: opensearch/distribution/archives/linux-tar/build/distributions
         run: |
-          docker run -p 9200:9200 -p 9600:9600 -d -e "discovery.type=single-node" -e "bootstrap.memory_lock=true" opensearch:test
-          sleep 90
+          pwd
+          tree
+          tar xf opensearch-min-*
+          ./opensearch-*/bin/opensearch &
+          for attempt in {1..20}; do sleep 5; if curl -s localhost:9200; then echo '=====> ready'; break; fi; echo '=====> waiting...'; done
 
       - name: Checkout High Level Python Client
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          path: dsl-py
 
-      - name: Install Nox
-        run: pip install nox
+      - name: Setup Python - ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+        env:
+          PIP_NO_PYTHON_VERSION_WARNING: 1
+
+      - name: Set up Python 3.8 for Nox
+        if: matrix.python-version != '3.8'
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+      - name: Install nox
+        run: |
+          python3.8 -m pip install nox
 
       - name: Run integration tests
+        working-directory: dsl-py
         run: |
           nox --no-error-on-missing-interpreter -rs lint test
+
+      - name: Save server logs
+        if: failed()
+        uses: actions/upload-artifact@v3
+        with:
+          name: opensearch-logs-${{ matrix.opensearch_ref }}-python-${{ matrix.python-version }}
+          path: |
+            opensearch/distribution/archives/linux-tar/build/distributions/**/logs/*
+
+  test-ubuntu-20:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        opensearch_ref: [ '1.x', '2.x', '2.0', 'main' ]
+        python-version: [ '3.5', '3.6' ]
+
+    steps:
+      - name: Checkout OpenSearch
+        uses: actions/checkout@v3
+        with:
+          repository: opensearch-project/opensearch
+          ref: ${{ matrix.opensearch_ref }}
+          path: opensearch
+
+      - name: Get OpenSearch branch top
+        id: get-key
+        working-directory: opensearch
+        run: echo key=`git log -1 --format='%H'` >> $GITHUB_OUTPUT
+
+      - name: Restore cached build
+        id: cache-restore
+        uses: actions/cache/restore@v3
+        with:
+          path: opensearch/distribution/archives/linux-tar/build/distributions
+          key: ${{ steps.get-key.outputs.key }}
+
+      - name: Assemble OpenSearch
+        if: steps.cache-restore.outputs.cache-hit != 'true'
+        working-directory: opensearch
+        run: ./gradlew :distribution:archives:linux-tar:assemble
+
+      - name: Save cached build
+        if: steps.cache-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        with:
+          path: opensearch/distribution/archives/linux-tar/build/distributions
+          key: ${{ steps.get-key.outputs.key }}
+
+      - name: Run OpenSearch
+        working-directory: opensearch/distribution/archives/linux-tar/build/distributions
+        run: |
+          pwd
+          tree
+          tar xf opensearch-min-*
+          ./opensearch-*/bin/opensearch &
+          for attempt in {1..20}; do sleep 5; if curl -s localhost:9200; then echo '=====> ready'; break; fi; echo '=====> waiting...'; done
+
+      - name: Checkout High Level Python Client
+        uses: actions/checkout@v3
+        with:
+          path: dsl-py
+
+      - name: Setup Python - ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+        env:
+          PIP_NO_PYTHON_VERSION_WARNING: 1
+
+      - name: Set up Python 3.8 for Nox
+        if: matrix.python-version != '3.8'
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+      - name: Install nox
+        run: |
+          python3.8 -m pip install nox
+
+      - name: Run integration tests
+        working-directory: dsl-py
+        run: |
+          nox --no-error-on-missing-interpreter -rs lint test
+
+      - name: Save server logs
+        if: failed()
+        uses: actions/upload-artifact@v3
+        with:
+          name: opensearch-logs-${{ matrix.opensearch_ref }}-python-${{ matrix.python-version }}
+          path: |
+            opensearch/distribution/archives/linux-tar/build/distributions/**/logs/*

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         version: [ '1.0.1', '1.1.0', '1.2.4', '1.3.7', '2.0.1', '2.1.0', '2.2.1', '2.3.0', '2.4.0', '2.5.0' ]
         secured: [ "true", "false" ]
-        python-version: [ '2.7', '3.7', '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.8' ]
 
     steps:
       - name: Checkout
@@ -38,61 +38,9 @@ jobs:
           PIP_DISABLE_PIP_VERSION_CHECK: 1
           PIP_NO_PYTHON_VERSION_WARNING: 1
 
-      - name: Set up Python 3.8 for Nox
-        if: matrix.python-version != '3.8'
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.8
       - name: Install nox
         run: |
-          python3.8 -m pip install --upgrade pip nox
-
-      - name: Integ OpenSearch secured=${{ matrix.secured }}
-        run: |
-          export SECURE_INTEGRATION=${{ matrix.secured }}
-          nox --no-error-on-missing-interpreter -rs lint test
-
-  integration-ubuntu-20:
-    name: Integ
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        version: [ '1.0.1', '1.1.0', '1.2.4', '1.3.7', '2.0.1', '2.1.0', '2.2.1', '2.3.0', '2.4.0', '2.5.0' ]
-        secured: [ "true", "false" ]
-        python-version: [ '3.5', '3.6' ]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Clean docker containers
-        run: |
-          docker volume prune --force
-          docker network prune --force
-          docker system prune --volumes --force
-
-      - name: Launch OpenSearch cluster
-        run: |
-          export OPENSEARCH_VERSION=${{ matrix.entry.version }}
-          export SECURE_INTEGRATION=${{ matrix.secured }}
-          docker-compose --project-directory .ci/opensearch build
-          docker-compose --project-directory .ci/opensearch up -d
-
-      - name: Setup Python - ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-        env:
-          PIP_DISABLE_PIP_VERSION_CHECK: 1
-
-      - name: Set up Python 3.8 for Nox
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.8
-      - name: Install nox
-        run: |
-          python3.8 -m pip install --upgrade pip nox
+          python -m pip install --upgrade pip nox
 
       - name: Integ OpenSearch secured=${{ matrix.secured }}
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,26 +9,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        entry:
-          - { version: 1.0.0 }
-          - { version: 1.0.1 }
-          - { version: 1.1.0 }
-          - { version: 1.2.0 }
-          - { version: 1.2.1 }
-          - { version: 1.2.2 }
-          - { version: 1.2.3 }
-          - { version: 1.2.4 }
-          - { version: 1.3.0 }
-          - { version: 1.3.1 }
-          - { version: 1.3.2 }
-          - { version: 1.3.3 }
-          - { version: 2.0.0 }
-          - { version: 2.0.1 }
-        secured: ["true", "false"]
+        version: [ '1.0.1', '1.1.0', '1.2.4', '1.3.7', '2.0.1', '2.1.0', '2.2.1', '2.3.0', '2.4.0', '2.5.0' ]
+        secured: [ "true", "false" ]
+        python-version: [ '2.7', '3.7', '3.8', '3.9', '3.10', '3.11' ]
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Clean docker containers
         run: |
@@ -43,8 +30,69 @@ jobs:
           docker-compose --project-directory .ci/opensearch build
           docker-compose --project-directory .ci/opensearch up -d
 
-      - name: Install Nox
-        run: pip install nox
+      - name: Setup Python - ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+        env:
+          PIP_DISABLE_PIP_VERSION_CHECK: 1
+          PIP_NO_PYTHON_VERSION_WARNING: 1
+
+      - name: Set up Python 3.8 for Nox
+        if: matrix.python-version != '3.8'
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+      - name: Install nox
+        run: |
+          python3.8 -m pip install --upgrade pip nox
+
+      - name: Integ OpenSearch secured=${{ matrix.secured }}
+        run: |
+          export SECURE_INTEGRATION=${{ matrix.secured }}
+          nox --no-error-on-missing-interpreter -rs lint test
+
+  integration-ubuntu-20:
+    name: Integ
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [ '1.0.1', '1.1.0', '1.2.4', '1.3.7', '2.0.1', '2.1.0', '2.2.1', '2.3.0', '2.4.0', '2.5.0' ]
+        secured: [ "true", "false" ]
+        python-version: [ '3.5', '3.6' ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Clean docker containers
+        run: |
+          docker volume prune --force
+          docker network prune --force
+          docker system prune --volumes --force
+
+      - name: Launch OpenSearch cluster
+        run: |
+          export OPENSEARCH_VERSION=${{ matrix.entry.version }}
+          export SECURE_INTEGRATION=${{ matrix.secured }}
+          docker-compose --project-directory .ci/opensearch build
+          docker-compose --project-directory .ci/opensearch up -d
+
+      - name: Setup Python - ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+        env:
+          PIP_DISABLE_PIP_VERSION_CHECK: 1
+
+      - name: Set up Python 3.8 for Nox
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+      - name: Install nox
+        run: |
+          python3.8 -m pip install --upgrade pip nox
 
       - name: Integ OpenSearch secured=${{ matrix.secured }}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
+- Update CI workflow python versions ([#92](https://github.com/opensearch-project/opensearch-dsl-py/pull/92))
 
 ### Security
 

--- a/opensearch_dsl/index.py
+++ b/opensearch_dsl/index.py
@@ -59,7 +59,6 @@ class IndexTemplate(object):
         return d
 
     def save(self, using=None):
-
         opensearch = get_connection(using or self._index._using)
         return opensearch.indices.put_template(
             name=self._template_name, body=self.to_dict()

--- a/opensearch_dsl/update_by_query.py
+++ b/opensearch_dsl/update_by_query.py
@@ -32,7 +32,6 @@ from .utils import recursive_to_dict
 
 
 class UpdateByQuery(Request):
-
     query = ProxyDescriptor("query")
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
### Description
![image](https://user-images.githubusercontent.com/88679692/213542628-f4c2514b-52d3-4fb1-aabd-c597256601f7.png)

`ubuntu-latest` was recently updated from `20.04` to `22.04` ([announcement](https://github.com/actions/runner-images/issues/6399)). [`setup-python`](https://github.com/actions/setup-python) action doesn't support `3.5` and `3.6` on `22.04` ([link](https://github.com/actions/setup-python/issues/561#issuecomment-1339798843)).


### Issues Resolved
Remove unsupported by GHA Python versions. Add newer versions instead.

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass.
- [ ] New functionality has been documented.
  - [ ] New functionality has comments added.
- [x] Commits are signed per the DCO using --signoff.
- [x] [CHANGELOG](https://github.com/opensearch-project/opensearch-dsl-py/blob/main/CONTRIBUTING.md#changelog) has been updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following the Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-dsl-py/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).