### PR TITLE
Remove unsupported versions from CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,13 +61,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         runner: ['ubuntu-latest']
-        include:
-          - runner: 'ubuntu-20.04'
-            python-version: '3.5'
-          - runner: 'ubuntu-20.04'
-            python-version: '3.6'
 
     steps:
       - name: Checkout Repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - Update CI workflow python versions ([#92](https://github.com/opensearch-project/opensearch-dsl-py/pull/92))
+- Remove unsupported versions from CI. ([#105](https://github.com/opensearch-project/opensearch-dsl-py/pull/105))
 
 ### Security
 


### PR DESCRIPTION
### Description
Remove unsupported python version from CI workflows.

### Issues Resolved
Fix CI failures, see [job run for example](https://github.com/opensearch-project/opensearch-dsl-py/actions/runs/4308686902) and [test run logs](https://github.com/opensearch-project/opensearch-dsl-py/files/10925779/logs_935.zip). `opensearch-py` starting from version 2.0.0 requires `certifi>=2022.12.07` which is not released for old python versions.
```
ERROR: Could not find a version that satisfies the requirement certifi>=2022.12.07 (from opensearch-py>=2.0.0->opensearch-dsl==2.0.1) (from versions: 0.0.1, 0.0.2, 0.0.3, 0.0.4, 0.0.5, 0.0.6, 0.0.7, 0.0.8, 1.0.0, 1.0.1, 14.5.14, 2015.4.28, 2015.9.6, 2015.9.6.1, 2015.9.6.2, 2015.11.20, 2015.11.20.1, 2016.2.28, 2016.8.2, 2016.8.8, 2016.8.31, 2016.9.26, 2017.1.23, 2017.4.17, 2017.7.27, 2017.7.27.1, 2017.11.5, 2018.1.18, 2018.4.16, 2018.8.13, 2018.8.24, 2018.10.15, 2018.11.29, 2019.3.9, 2019.6.16, 2019.9.11, 2019.11.28, 2020.4.5, 2020.4.5.1, 2020.4.5.2, 2020.6.20, 2020.11.8, 2020.12.5, 2021.5.30, 2021.10.8)
ERROR: No matching distribution found for certifi>=2022.12.07 (from opensearch-py>=2.0.0->opensearch-dsl==2.0.1)
```
Ref: https://github.com/opensearch-project/opensearch-py/issues/309#issuecomment-1452309961

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
