### PR TITLE
Add more params in Search.from_dict()

### DIFF
--- a/opensearch_dsl/search.py
+++ b/opensearch_dsl/search.py
@@ -387,7 +387,7 @@ class Search(Request):
             return s
 
     @classmethod
-    def from_dict(cls, d):
+    def from_dict(cls, d, **kwargs):
         """
         Construct a new `Search` instance from a raw dict containing the search
         body. Useful when migrating from raw dictionaries.
@@ -404,7 +404,7 @@ class Search(Request):
             })
             s = s.filter('term', published=True)
         """
-        s = cls()
+        s = cls(**kwargs)   # params same as __init__(**kwargs)
         s.update_from_dict(d)
         return s
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -399,14 +399,15 @@ def test_reverse():
         "script_fields": {"more_attendees": {"script": "doc['attendees'].value + 42"}},
     }
 
+    o = object
     d2 = deepcopy(d)
-
-    s = search.Search.from_dict(d)
+    s = search.Search.from_dict(d, using=o)
 
     # make sure we haven't modified anything in place
     assert d == d2
     assert {"size": 5} == s._extra
     assert d == s.to_dict()
+    assert s._using is o
 
 
 def test_from_dict_doesnt_need_query():


### PR DESCRIPTION
### Description
When I use query dict to create a Search object, this function only receive one param, no more params such as using index

Although I can use using() and index() after create object to adjust the object, but these function will copy more object in the s = self._clone() function.

I think these operations are unnecessary.

Reference: https://github.com/opensearch-project/opensearch-dsl-py/issues/109

### Issues Resolved
Add more params in `Search.from_dict()`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
